### PR TITLE
Fixed error

### DIFF
--- a/lib/sign_in.dart
+++ b/lib/sign_in.dart
@@ -38,7 +38,7 @@ Future<String> signInWithGoogle() async {
     idToken: googleSignInAuthentication.idToken,
   );
 
-  final FirebaseUser user = await _auth.signInWithCredential(credential);
+  final FirebaseUser user = (await _auth.signInWithCredential(credential)).user;
 
   // Checking if email and name is null
   assert(user.email != null);


### PR DESCRIPTION
_auth.signInWithCredential returns a AuthResult, not a FirebaseUser