### PR TITLE
Added Browser Dependency

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -60,4 +60,5 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
     implementation 'com.google.firebase:firebase-core:17.0.0'
+    implementation 'androidx.browser:browser:1.2.0'
 }


### PR DESCRIPTION
Everytime, I pressed for OTP my app crashing.Finally,this thing help me out.
Now,browser can be opened up easily for verification.